### PR TITLE
Reexec systemd instead of restarting a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Simple Ansible role to upgrade hosts, based on [debian_upgrade.yml](https://gist
 
 ## Role Variables
 
-| Option                            | Type    | Default | Description                                                                      | Required |
-|:----------------------------------|:--------|:--------|:---------------------------------------------------------------------------------|:--------:|
-| `upgrade_restart_services`        | boolean | `true`  | Automatically restart services, when needed(for ex. linked libaries are updated) |    N     |
-| `upgrade_restart_services_ignore` | list    | `[]`    | List of services that shall not be restarted. `dbus` is always appended.         |    N     |
+| Option                            | Type    | Default | Description                                                                    | Required |
+|:----------------------------------|:--------|:--------|:-------------------------------------------------------------------------------|:--------:|
+| `upgrade_restart_services`        | boolean | `true`  | Automatically restart services, when needed (e.g. linked libaries are updated) | N        |
+| `upgrade_restart_services_ignore` | list    | `[]`    | List of services that shall not be restarted. `dbus` is always appended.       | N        |
+
+You cannot list systemd in the list of ignored services, the `systemctl daemon-reexec` will always be executed when a library dependency of systemd changes.
 
 ## License
 

--- a/tasks/upgrade_debian.yml
+++ b/tasks/upgrade_debian.yml
@@ -48,4 +48,8 @@
     name: "{{ item }}"
     state: restarted
   with_items: "{{ services.stdout_lines }}"
-  when: services.stdout_lines and upgrade_restart_services and item not in upgrade_restart_services_ignore | union(['dbus'])
+  when: services.stdout_lines and upgrade_restart_services and item not in upgrade_restart_services_ignore | union(['dbus', 'systemd'])
+
+- name: Reexec systemd
+  command: systemctl daemon-reexec
+  when: "services.stdout_lines and 'systemd' in services.stdout_lines"


### PR DESCRIPTION
Otherwise, the role tries to restart a service called 'systemd'.