### PR TITLE
upgrade_debian.yml: [Bugfix] Restart only services

### DIFF
--- a/tasks/upgrade_debian.yml
+++ b/tasks/upgrade_debian.yml
@@ -35,7 +35,7 @@
   when: ansible_lsb.release != new_release.stdout
 
 - name: List services to restart (1/2)
-  shell: needrestart -b -r l | grep ^NEEDRESTART-SVC | awk -F '[ .]' '{print $2}'
+  shell: needrestart -b -r l | grep ^NEEDRESTART-SVC | grep -F .service | awk -F '[ .]' '{print $2}'
   register: services
   changed_when: False
 


### PR DESCRIPTION
The `grep ^NEEDRESTART-SVC` could yield the line

```
NEEDRESTART-SVC: systemd-manager
```

and thus the role tried to restart `systemd-manager`. This commit
is a bugfix.